### PR TITLE
Changed the default setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 Right click in any .mgcb file to open it in the MonoGame pipeline tool.
 
 ![Screenshot](screenshot.png)
+
+## Prerequisites
+
+Install Monogame Pipeline .NET tool. You can install it using the following scripts
+
+```
+dotnet tool install --global dotnet-mgcb-editor
+mgcb-editor --register
+```
+
+Source: [Monogame Documentation](https://docs.monogame.net/articles/getting_started/1_setting_up_your_development_environment_ubuntu.html#install-mgcb-editor)
+
+Note: If you are using the older versions of the Monogame pipeline, then you need to update its path in the project's setting accordingly

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 			"properties": {
 				"mgcb.pipelineToolPath": {
 					"type": "string",
-					"default": "monogame-pipeline-tool",
+					"default": "mgcb-editor",
 					"description": "Pipeline tool executable path."
 				}
 			}


### PR DESCRIPTION
# Description

- Changed the default command to `mgcb-editor`

Installing the Monogame pipeline tool, the `mgcb-editor` can be used/invoked globally. Therefore, the default setting is changed to "mgcb-editor". Also added a bit of instruction in the README.md 